### PR TITLE
Better integration for a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ target_link_libraries(${TARGET} PRIVATE avformat avcodec avutil swscale swresamp
 ```
 QT += quick multimedia
 
-include(qmlav/qmlav.pri)
+include($$PWD/qmlav/qmlav.pri)
 
 android {
     INCLUDEPATH += ./qmlav/3rd/FFmpeg
@@ -55,7 +55,7 @@ LIBS += -lavcodec -lavdevice -lavformat -lavutil -lswresample -lswscale
 3. Register the QML type before using:
 
 ```
-#include "qmlav/src/qmlavplayer.h"
+#include <qmlavplayer.h>
 
 qmlRegisterType<FFPlayer>("QmlAV.Multimedia", 1, 0, "QmlAVPlayer");
 

--- a/qmlav.pri
+++ b/qmlav.pri
@@ -1,5 +1,7 @@
 #DEFINES += NO_DEBUG
 
+INCLUDEPATH += $$PWD/src
+
 HEADERS += \
     $$PWD/src/qmlavaudioqueue.h \
     $$PWD/src/qmlavdecoder.h \


### PR DESCRIPTION
I changed a few things to better adapt to a project. It was an issue on my side, and I figured I would open a pull request to fix this issue.
The `.pri` now has an `include path`, to use `#include <example.h>` instead of `include "path/to/example.h"`
The QMake config is also a bit changed. A young developer will now be able to copy and paste the README for their project.