### PR TITLE
Add videoFramePresented signal

### DIFF
--- a/src/qmlavplayer.cpp
+++ b/src/qmlavplayer.cpp
@@ -118,6 +118,8 @@ void QmlAVPlayer::frameHandler(const std::shared_ptr<QmlAVFrame> frame)
                 if (m_videoSurface->isActive()) {
                     if (!m_videoSurface->present(qvf)) {
                         stop();
+                    } else {
+                        emit videoFramePresented();
                     }
                 }
             }

--- a/src/qmlavplayer.h
+++ b/src/qmlavplayer.h
@@ -41,6 +41,9 @@ public:
     virtual void classBegin() override {}
     virtual void componentComplete() override;
 
+signals:
+    void videoFramePresented();
+
 public slots:
     void play();
     void stop();


### PR DESCRIPTION
## Summary
- Adds a `videoFramePresented` signal emitted each time a video frame is successfully presented to the video surface
- Enables QML consumers to count or respond to presented frames without requiring a cumulative counter property, preventing integer overflow on long-running streams

## Use case
This signal enables per-viewport FPS measurement in QML by connecting to it with a simple frame counter:

```qml
Connections {
    target: qmlAvPlayer
    onVideoFramePresented: fpsCounter.frameCount++
}
```

The signal-based approach leaves counting and sampling logic to the QML consumer, which can reset its counter each interval to avoid overflow.

## Changes
- `src/qmlavplayer.h` — Add `videoFramePresented()` signal declaration
- `src/qmlavplayer.cpp` — Emit signal after successful `m_videoSurface->present()`